### PR TITLE
Kubernetes logging

### DIFF
--- a/kubernetes-logging/grafana/values.yaml
+++ b/kubernetes-logging/grafana/values.yaml
@@ -1,0 +1,7 @@
+nodeSelector:
+  node-role: infra-lbl
+tolerations:
+- key: "node-role"
+  operator: "Equal"
+  value: "infra"
+  effect: "NoSchedule"

--- a/kubernetes-logging/loki-chart/values.yaml
+++ b/kubernetes-logging/loki-chart/values.yaml
@@ -1,0 +1,91 @@
+fullnameOverride: loki
+
+nodeSelector:
+  node-role: infra-lbl
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  schemaConfig:
+    configs:
+    - from: "2024-01-01"
+      store: tsdb
+      index:
+        prefix: loki_index_
+        period: 24h
+      object_store: s3
+      schema: v13
+  storage:
+    type: 's3'
+    bucketNames:
+      chunks: hw-logging-s3
+      ruler: hw-logging-s3
+      admin: hw-logging-s3
+    s3:
+      endpoint: storage.yandexcloud.net/hw-logging-s3
+      region: ru-central1-b
+      secretAccessKey: key*********************************Npp
+      accessKeyId: ID*******************************Your
+      s3ForcePathStyle: false
+      insecure: false
+deploymentMode: SingleBinary
+singleBinary:
+  replicas: 1
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+  nodeSelector: 
+    node-role: infra-lbl
+write:
+  replicas: 0
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+read:
+  replicas: 0
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+backend:
+  replicas: 0
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+gateway:
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+resultsCache:
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+chunksCache:
+  enabled: false
+  # tolerations:
+  # - key: "node-role"
+  #   operator: "Equal"
+  #   value: "infra"
+  #   effect: "NoSchedule"
+  # nodeSelector: 
+  #   node-role: infra-lbl
+lokiCanary:
+  tolerations:
+  - key: "node-role"
+    operator: "Equal"
+    value: "infra"
+    effect: "NoSchedule"
+  nodeSelector: 
+    node-role: infra-lbl

--- a/kubernetes-logging/promtail/values.yaml
+++ b/kubernetes-logging/promtail/values.yaml
@@ -1,0 +1,17 @@
+fullnameOverride: promtail-hw
+
+config:
+# publish data to loki
+  clients:
+    - url: http://loki-gateway.loki.svc.cluster.local/loki/api/v1/push
+      tenant_id: 1
+
+# Leave it here by default to schedule Pods for all node-groups
+nodeSelector: {}
+
+# -- Tolerations for pods. By default, pods will be scheduled on master/control-plane nodes.
+tolerations:
+- key: "node-role"
+  operator: "Equal"
+  value: "infra"
+  effect: "NoSchedule"


### PR DESCRIPTION
# Выполнено ДЗ №

 - [Х] Основное ДЗ

## В процессе сделано:
 - Выполнено всё ДЗ, а именно:
    - Создано через UI Yandex Cloud:
      - Managed Kubernetes Cluster
      - S3 Storage с роботом с минимальными и достаточными правами на запись/чтение
      - создан Service Account для возможности подключаться к Yandex Cloud через CLI
![image (7)](https://github.com/user-attachments/assets/44491ad6-305c-4a96-830f-57ddee04d7d1)

    - Создано 2 пула нод по одной ноде в каждом из них, установлены соответствующие taints и tolerations:
```
$ kubectl get node -o wide --show-labels
NAME                        STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME     LABELS
cl1247vgqr8amrvd0s71-emax   Ready    <none>   3d    v1.27.3   10.129.0.25   84.252.143.47    Ubuntu 20.04.6 LTS   5.4.0-177-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-b,kubernetes.io/arch=amd64,kubernetes.io/hostname=cl1247vgqr8amrvd0s71-emax,kubernetes.io/os=linux,node-role=payload,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,topology.kubernetes.io/zone=ru-central1-b,yandex.cloud/node-group-id=catdo1jigoti3vkhd71q,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
cl12h6m2sa545kb5h3h4-uzyv   Ready    <none>   3d    v1.27.3   10.129.0.16   84.201.154.191   Ubuntu 20.04.6 LTS   5.4.0-177-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-b,kubernetes.io/arch=amd64,kubernetes.io/hostname=cl12h6m2sa545kb5h3h4-uzyv,kubernetes.io/os=linux,node-role=infra-lbl,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,topology.kubernetes.io/zone=ru-central1-b,yandex.cloud/node-group-id=caths987798t0gc57ffl,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
```

```
$ kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
NAME                        TAINTS
cl1247vgqr8amrvd0s71-emax   <none>
cl12h6m2sa545kb5h3h4-uzyv   [map[effect:NoSchedule key:node-role value:infra]]
```

    - В Grafana настроен dataSource к loki. Скриншот прилагаю.

 ![image (6)](https://github.com/user-attachments/assets/bc8346c4-aa97-4635-acfc-f596925867cc)

## Как запустить проект:
  - Установить loki, promtail и grafana через helm чарт, каждый со своими values:
```
helm install --values values.yaml -n loki [promtail|loki|grafana] grafana/[promtail|loki|grafana]
```

## Как проверить работоспособность:
 - Сделать форвард порта с Пода Графаны и перейти по ссылке http://localhost:3000 к Grafana и сделать Explore данных по Loki

## PR checklist:

 - [ ] Выставлен label с темой домашнего задания
